### PR TITLE
Restore text-selection popups in panels and after bus outages

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Under **Excluded apps**, choose **Add from running windows…** and search for
 an app or window title. Selecting a window ignores its whole application;
 click **×** beside an entry to remove it, even after that app has closed.
 The terminal list remains an advanced text field with common terminals filled in.
+Interactive panels above a window use their layer namespace (`layer:<namespace>`)
+as the app identity, so a terminal behind a panel does not require Shift there.
 
 If you hide the bar icon, you can still open the settings screen with
 `omarchy-shell io.github.jondkinney.omapop settings` and turn the icon back on.
@@ -518,7 +520,8 @@ processes. The boundaries, and the contract at each:
   It turns on the session accessibility flag, which is what makes
   toolkits expose their widget trees to assistive technology; that is a
   same-user surface, and the setting **Detect editable fields via
-  accessibility** turns the helper off.
+  accessibility** turns the helper off. If the bus becomes unavailable, the helper
+  retries every three seconds at first, then every 30 seconds until it recovers.
 - **Display**: every `Text` showing external strings uses `Text.PlainText`
   after control and bidi characters are stripped and the length is capped.
 
@@ -543,6 +546,7 @@ python3 -m unittest discover -s tests -p 'test_*.py'   # helpers, directory
 node tests/actions.test.mjs
 node tests/gestures.test.mjs                        # click timing and stale read callbacks
 node tests/settings.test.mjs                        # typed settings and preservation of other preferences
+node tests/context-recovery.test.mjs                 # helper recovery after an accessibility bus outage
 node tests/engine-config.test.mjs                    # settings updates in the running Lua engine
 node tests/extension-policy.test.mjs                # ordered effects, opt-in, per-extension preferences
 node tests/http.test.mjs                            # request deadlines and streamed byte limits

--- a/Service.qml
+++ b/Service.qml
@@ -493,16 +493,16 @@ Item {
         }
         onExited: function (code, status) {
             root.contextFailures += 1
-            if (root.accessibilityProbe && root.contextFailures < 5)
+            if (root.accessibilityProbe)
                 contextRestart.restart()
-            else if (root.contextFailures >= 5)
-                log("accessibility helper keeps exiting; editable-field detection is off")
+            if (root.contextFailures === 5)
+                log("accessibility helper is unavailable; retrying every 30 seconds")
         }
     }
 
     Timer {
         id: contextRestart
-        interval: 3000
+        interval: root.contextFailures < 5 ? 3000 : 30000
         onTriggered: if (root.accessibilityProbe && !contextProc.running) contextProc.running = true
     }
 
@@ -540,6 +540,7 @@ Item {
         var msg = parseJson(line, 4096)
         if (!msg || typeof msg !== "object" || msg.id === undefined || msg.id === null)
             return
+        root.contextFailures = 0
         var w = contextWaiters[msg.id]
         if (!w)
             return

--- a/Service.qml
+++ b/Service.qml
@@ -46,7 +46,7 @@ Item {
     readonly property string contextHelper: pluginDir + "/bin/omapop-context.py"
     readonly property string nativeHelper: pluginDir + "/bin/omapop-native.py"
     readonly property string directoryHelper: pluginDir + "/bin/omapop-directory.py"
-    readonly property int engineVersion: 4
+    readonly property int engineVersion: 5
 
     // Children get only what they need to reach the compositor and the display.
     readonly property var childEnv: ({

--- a/engine.lua
+++ b/engine.lua
@@ -1,4 +1,4 @@
-local ENGINE_VERSION = 4
+local ENGINE_VERSION = 5
 local BIND_KEYS = { "mouse:272", "mouse:273", "mouse:274", "mouse_up", "mouse_down" }
 
 local previous = rawget(_G, "__omapop")
@@ -120,6 +120,32 @@ local function context_fields(x, y)
         w.x = num(at.x, "")
         w.y = num(at.y, "")
       end
+    end
+  end)
+  -- A keyboard-interactive top/overlay panel receives the selection even
+  -- while get_active_window() still identifies a terminal underneath it.
+  -- Keep layer identities distinct from window addresses: action dispatchers
+  -- must use the focused surface, never target the underlying window.
+  pcall(function()
+    local layers = hl.get_layers({ monitor = m.name })
+    if type(layers) ~= "table" or #layers > 256 then return end
+    local chosen, level = nil, -1
+    for _, layer in ipairs(layers) do
+      local kind = tonumber(layer.layer) or -1
+      local interactive = tonumber(layer.keyboard_interactivity or layer.interactivity) or 0
+      local lx, ly, lw, lh = tonumber(layer.x), tonumber(layer.y), tonumber(layer.w), tonumber(layer.h)
+      if layer.mapped == true and kind >= 2 and kind >= level and interactive > 0
+          and layer.namespace ~= "omapop" and lx and ly and lw and lh and lw > 0 and lh > 0
+          and x >= lx and x < lx + lw and y >= ly and y < ly + lh then
+        chosen, level = layer, kind
+      end
+    end
+    if chosen then
+      w.class = "layer:" .. tostring(chosen.namespace or "")
+      w.title = tostring(chosen.namespace or "")
+      w.address = "layer:" .. tostring(chosen.address or "")
+      w.pid = num(chosen.pid, 0)
+      w.x, w.y = num(chosen.x, ""), num(chosen.y, "")
     end
   end)
   return { x, y, mods(), m.name, m.x, m.y, m.w, m.h, m.scale, w.class, w.title, w.address, w.pid, w.x, w.y }

--- a/tests/context-recovery.test.mjs
+++ b/tests/context-recovery.test.mjs
@@ -1,0 +1,47 @@
+// Run the production helper lifecycle handlers without touching the session bus.
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import assert from "node:assert/strict";
+
+const source = readFileSync(new URL("../Service.qml", import.meta.url), "utf8");
+const processBlock = source.match(/    Process \{\n        id: contextProc\n[^]*?^    \}/m)[0];
+const exitHandler = processBlock.match(/onExited: function \(code, status\) \{([^]*?)\n        \}/)[1];
+const timerBlock = source.match(/    Timer \{\n        id: contextRestart\n[^]*?^    \}/m)[0];
+const interval = timerBlock.match(/interval: (.*)/)[1];
+const trigger = timerBlock.match(/onTriggered: (.*)/)[1];
+const response = source.match(/^    function onContextLine\(line\) \{[^]*?^    \}/m)[0];
+const delays = [], logs = [];
+let scheduled = false;
+const context = vm.createContext({
+  contextFailures: 0, accessibilityProbe: true, contextWaiters: {},
+  contextProc: { running: false }, parseJson: JSON.parse,
+  log: value => logs.push(value),
+  contextRestart: { restart() {
+    scheduled = true;
+    delays.push(vm.runInContext(interval, context));
+  } },
+});
+context.root = context;
+vm.runInContext(response, context);
+for (let attempt = 0; attempt < 8; attempt++) {
+  context.contextProc.running = false;
+  scheduled = false;
+  vm.runInContext(exitHandler, context);
+  assert.equal(scheduled, true, "an unavailable bus must not permanently disable the helper");
+  vm.runInContext(trigger, context);
+  assert.equal(context.contextProc.running, true);
+}
+assert.deepEqual(delays, [3000, 3000, 3000, 3000, 30000, 30000, 30000, 30000]);
+assert.equal(logs.length, 1, "an extended outage must not flood the log");
+context.onContextLine('{"id":1,"editable":false}');
+assert.equal(context.contextFailures, 0, "a valid response resets the backoff");
+context.contextProc.running = false;
+vm.runInContext(exitHandler, context);
+assert.equal(delays.at(-1), 3000);
+context.accessibilityProbe = false;
+scheduled = false;
+vm.runInContext(exitHandler, context);
+assert.equal(scheduled, false);
+vm.runInContext(trigger, context);
+assert.equal(context.contextProc.running, false, "disabling the probe must prevent pending restarts");
+console.log("Accessibility helper recovery tests passed");

--- a/tests/engine.test.lua
+++ b/tests/engine.test.lua
@@ -3,6 +3,7 @@
 local path = arg[1] or ((arg[0]:match("^(.*)/") or ".") .. "/../engine.lua")
 local bindings, subscriptions, timers, events = {}, {}, {}, {}
 local x, y, mask = 100, 100, 0
+local layers = {}
 local modifier_masks = {
   Shift_L = 1, Shift_R = 1, Control_L = 4, Control_R = 4,
   Alt_L = 8, Alt_R = 8, Super_L = 64, Super_R = 64,
@@ -13,6 +14,7 @@ hl = {
   get_cursor_pos = function() return { x = x, y = y } end,
   get_monitor_at_cursor = function() return { name = "test", width = 1920, height = 1080, scale = 1 } end,
   get_active_window = function() return { class = "foot", title = "test", address = "0x1", pid = 1, at = { x = -1920, y = 38 } } end,
+  get_layers = function() return layers end,
   is_key_down = function(key) return (mask & (modifier_masks[key] or 0)) ~= 0 end,
   timer = function(callback) timers[#timers + 1] = callback end,
   bind = function(key, callback, options)
@@ -60,6 +62,40 @@ for _, held in ipairs({ 0, 1, 4, 8, 64, 5 }) do
   assert(events[before + 2]:sub(-12) == "|100|100|0|0", "release must preserve the drag origin")
   assert(events[before + 2]:find("|0x1|1|-1920|38|", 1, true), "release must include the active window origin")
 end
+
+-- A panel above a terminal owns selections within its interactive bounds.
+local function release_context()
+  mask, x, y = 0, 100, 100
+  dispatch_mouse("mouse:272", false)
+  x = 180
+  dispatch_mouse("mouse:272", true)
+  return events[#events]
+end
+local panel = { mapped = true, layer = 2, interactivity = 2,
+  namespace = "test-panel", address = "0x2", pid = 2, x = 80, y = 80, w = 300, h = 200 }
+layers = { panel }
+assert(release_context():find("|layer%3Atest-panel|test-panel|layer%3A0x2|2|80|80|", 1, true),
+  "interactive layers must replace the underlying terminal context")
+-- Newer Hyprland calls the property keyboard_interactivity.
+panel.interactivity, panel.keyboard_interactivity = nil, 2
+assert(release_context():find("|layer%3Atest-panel|", 1, true))
+for key, value in pairs({ mapped = false, layer = 1, keyboard_interactivity = 0, x = 400, w = 0 }) do
+  local saved = panel[key]
+  panel[key] = value
+  assert(release_context():find("|foot|test|0x1|", 1, true), "non-target layers must preserve terminal filtering: " .. key)
+  panel[key] = saved
+end
+local overlay = { mapped = true, layer = 3, interactivity = 1,
+  namespace = "test-overlay", address = "0x3", pid = 3, x = 0, y = 0, w = 400, h = 400 }
+layers = { overlay, panel }
+assert(release_context():find("|layer%3Atest-overlay|", 1, true), "the highest interactive layer must win")
+overlay.namespace = "omapop"
+assert(release_context():find("|layer%3Atest-panel|", 1, true), "the popup must not become its own source")
+local query = hl.get_layers
+hl.get_layers = nil
+assert(release_context():find("|foot|test|0x1|", 1, true), "older compositors must retain window context")
+hl.get_layers = query
+layers = {}
 
 -- Modified clicks still dismiss the bar, and Shift does not get consumed.
 mask = 1


### PR DESCRIPTION
Selecting text in a keyboard-interactive panel above a terminal was treated as a terminal selection, so Omapop required Shift and stayed hidden. Resolve the mapped top/overlay layer under the pointer before applying app rules. Layer identities also prevent action shortcuts from targeting the underlying window. Older compositors retain the existing window fallback.

The accessibility helper also stopped retrying after five failures. Keep retrying every 30 seconds after the initial quick attempts and reset the backoff after a valid response, so an accessibility-bus interruption can recover without restarting the shell.

Validation: Lua engine tests cover layer bounds, interactivity, stacking, fallback, modifiers, and reloads; 92 gesture test groups, engine configuration, helper recovery, and isolated plugin loading pass. A disposable Omarchy VM reproduced the missing popup in a synthetic Blip contact panel above Foot before the fix, then verified popup appearance and its Copy action in both panel and window modes afterward. Keyboard and right-click copies also passed. Synthetic screenshots were inspected; no real conversation was opened or message sent.
